### PR TITLE
Add the ability to add extras info on label (KNP)

### DIFF
--- a/Resources/docs/knp_menu.md
+++ b/Resources/docs/knp_menu.md
@@ -77,6 +77,14 @@ class KnpMenuBuilderSubscriber implements EventSubscriberInterface
         $menu->getChild('blogId')->addChild('ChildOneItemId', [
             'route' => 'child_1_route',
             'label' => 'ChildOneDisplayName',
+            'extras' => [
+                'label-extras' => [
+                    [
+                        'color' => 'green',
+                        'content' => 6,
+                    ],
+                ],
+            ],
             'childOptions' => $event->getChildOptions()
         ])->setLabelAttribute('icon', 'fas fa-rss-square');
         

--- a/Resources/views/Partials/_menu.html.twig
+++ b/Resources/views/Partials/_menu.html.twig
@@ -11,6 +11,15 @@
             <i class="fas fa-angle-left pull-right"></i>
         </span>
     {% endif %}
+    {% if item.getExtra('label-extras', null) is not null %}
+        <span class="pull-right-container">
+            {% for labelExtra in item.getExtra('label-extras')  %}
+                <small class="label pull-right bg-{{ labelExtra.color }}">
+                    {{ labelExtra.content|default('small') }}
+                </small>
+            {% endfor %}
+        </span>
+    {% endif %}
 {% endblock %}
 
 {% block list %}


### PR DESCRIPTION
Allows you to add extra information on label (pull-right content)

![image](https://user-images.githubusercontent.com/4682556/78116205-42585d80-7404-11ea-8816-d2905517d7ba.png)


## Description
It doesn't seem to be the right way of doing it, but it can be a first implementation.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I updated the documentation (see [here](https://github.com/kevinpapst/AdminLTEBundle/tree/master/Resources/docs))
- [x] I agree that this code is used in AdminLTEBundle and will be published under the [MIT license](https://github.com/kevinpapst/AdminLTEBundle/blob/master/LICENSE)
